### PR TITLE
Add binder link for qiskit 2x

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,18 +1,19 @@
 # How to install `qiskit==0.2x.x` 
 
-## on Linux x86_64
+## on x86_64 or AMD64 (Windows/MacOS/Linux) <!-- TODO: Needs to check windows & macos-->
 
-1. install anaconda and create environment as usual
+1. install anaconda and create environment as usual. Python version should be 3.8!
     ```bash
     conda create -n qiskit-2x python=3.8
     conda activate qiskit-2x
     ```
-2. Unlike newer versions, you have to install `Rust` for older versions of qiskit.
+    <!-- 2. Unlike newer versions, you have to install `Rust` for older versions of qiskit.
     ```bash
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     source $HOME/.cargo/env
-    ```
-3. Now you can downgrade to older versions of qiskit from source, or `pip`
+    ``` tuns out, this is not required -->
+
+3. Now you can downgrade to older versions of qiskit from source, or with `pip`
     ```bash
     pip install -U qiskit==0.2x.x
     ```
@@ -21,3 +22,7 @@
     ```bash
     pip install matplotlib==3.4.3 ipywidgets ipykernel pylatexenc seaborn
     ```
+
+## on Apple Silicon
+
+Not allowed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 
 # Qiskit-Dev-Cert-lectures
 
-## 소개
-
 이 노트들은 한국의 Qiskit Community 멤버들이 Qiskit 개발자 자격 시험을 준비할때 도움이 되기 위해 만들어졌습니다. 각 강의 영상들은 개방된 오픈소스 [오픈튜토리얼스](https://www.opentutorials.org/course/4973)에서 확인할 수 있습니다.
 
 
@@ -12,7 +10,7 @@
 
 - [신소영](https://github.com/0sophy1)
 - [최인호](https://github.com/q-inho)
-- [박시헌](https://github.com/Siheon-Park) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Siheon-Park/Qiskit-Dev-Cert-lectures/binder-trial)
+- [박시헌](https://github.com/Siheon-Park)
 
 ### 많은 도움이 된 자료들
 1. [Qiskit 공식 교육 자료](http://qiskit.org/learn)
@@ -24,9 +22,22 @@
 7.  [Bartu Bisgin의 Qiskit 자격증 시험 워크북](https://github.com/bartubisgin/qiskit-certified-exam-workbook)
 8.  [Dimple12M의 가이드](https://github.com/dimple12M/Qiskit-Certification-Guide)
 
+## 유의사항
+
+Qiskit 개발자 자격 시험은 `v0.2x.x`를 기준으로 합니다. 따라서 이 강의 노트들은 `v0.2x.x` 버전을 기준으로 작성되어 최신 Qiskit 버전에서는 작동하지 않을 수 있습니다. 따라서, 로컬 환경에서 Qiskit `v0.2x.x`를 설치하거나,
+
+```bash
+conda create -n qiskit-2x python=3.8
+conda activate qiskit-2x
+pip install -U qiskit==0.2x.x
+pip install matplotlib==3.4.3 ipywidgets ipykernel pylatexenc seaborn
+```
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantumComputingKorea/Qiskit-Dev-Cert-lectures/HEAD) 에서 강의 자료를 실행해주세요.
 ## 강의 구성
 
-이 강의는 선형대수학과 양자역학이 낯선 분들을 위한 두개의 선행 노트와 함께 실질적인 개발자 시험을 준비하는데 도움이 될 다섯 개의 Jupyter notebook으로 구성되어 있습니다.  교재의 구성은 다음과 같습니다.
+이 강의는 선형대수학과 양자역학이 낯선 분들을 위한 두개의 선행 노트와 함께 실질적인 개발자 시험을 준비하는데 도움이 될 다섯 개의 Jupyter notebook으로 구성되어 있습니다.
+교재의 구성은 다음과 같습니다.
 
 **Lecture 0: Into the rabbit hole** ([Link](https://github.com/QuantumComputingKorea/Qiskit-Dev-Cert-lectures/blob/main/Lecture0/lecture%200-0%20%20%EC%96%91%EC%9E%90%EC%BB%B4%ED%93%A8%ED%84%B0%EB%A5%BC%20%EC%9C%84%ED%95%9C%20%EC%84%A0%ED%98%95%EB%8C%80%EC%88%98.ipynb))
 1. 선형대수
@@ -90,7 +101,3 @@
 >Use Qiskit Toolkit  
 >Display and use system information  
 >Sample test + lab materials  
-
-## 유의사항
-
-Qiskit 개발자 자격 시험은 `v0.2x.x`를 기준으로 합니다. 따라서 이 강의 노트들은 `v0.2x.x` 버전을 기준으로 작성되어 최신 Qiskit 버전에서는 작동하지 않을 수 있습니다. 따라서, [링크](https://github.com/QuantumComputingKorea/Qiskit-Dev-Cert-lectures/blob/main/HOWTO.md)를 참고하여 `v0.2x.x` 버전을 설치하거나, 바인더( [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Siheon-Park/Qiskit-Dev-Cert-lectures/main) )를 통해 강의 노트를 실행해주세요.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## 유의사항
 
-Qiskit 개발자 자격 시험은 `v0.2x.x`를 기준으로 합니다. 따라서 이 강의 노트들은 `v0.2x.x` 버전을 기준으로 작성되어 최신 Qiskit 버전에서는 작동하지 않을 수 있습니다. 따라서, 로컬 환경에서 Qiskit `v0.2x.x`를 설치하거나,
+Qiskit 개발자 자격 시험은 `v0.2x.x`를 기준으로 합니다. 따라서 이 강의 노트들은 `v0.2x.x` 버전을 기준으로 작성되어 최신 Qiskit 버전에서는 작동하지 않을 수 있습니다. 따라서, 로컬 환경 또는 [IBM Quantum Lab](https://lab.quantum-computing.ibm.com/)에서 Qiskit `v0.2x.x`를 아래를 참고하여 설치하거나, [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantumComputingKorea/Qiskit-Dev-Cert-lectures/HEAD) 에서 강의 자료를 실행해주세요.
 
 ```bash
 conda create -n qiskit-2x python=3.8
@@ -33,7 +33,6 @@ pip install -U qiskit==0.2x.x
 pip install matplotlib==3.4.3 ipywidgets ipykernel pylatexenc seaborn
 ```
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantumComputingKorea/Qiskit-Dev-Cert-lectures/HEAD) 에서 강의 자료를 실행해주세요.
 ## 강의 구성
 
 이 강의는 선형대수학과 양자역학이 낯선 분들을 위한 두개의 선행 노트와 함께 실질적인 개발자 시험을 준비하는데 도움이 될 다섯 개의 Jupyter notebook으로 구성되어 있습니다.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 
 # Qiskit-Dev-Cert-lectures
 
+## 소개
+
 이 노트들은 한국의 Qiskit Community 멤버들이 Qiskit 개발자 자격 시험을 준비할때 도움이 되기 위해 만들어졌습니다. 각 강의 영상들은 개방된 오픈소스 [오픈튜토리얼스](https://www.opentutorials.org/course/4973)에서 확인할 수 있습니다.
 
 
 이 강의 노트를 커뮤니티 여러분과 함께 만들어가기 원합니다! 기여를 원하시는 분들은 Readme의 "제작 및 검수에 참여한 사람들"에 여러분의 이름을 추가하신 후 컨텐츠를 추가, 수정하여 PR을 보내주세요.
 
-<b>제작 및 검수에 참여한 사람들:</b>
+### 제작 및 검수에 참여한 사람들
 
 - [신소영](https://github.com/0sophy1)
 - [최인호](https://github.com/q-inho)
 - [박시헌](https://github.com/Siheon-Park) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Siheon-Park/Qiskit-Dev-Cert-lectures/binder-trial)
 
-<b>많은 도움이 된 자료들</b>
+### 많은 도움이 된 자료들
 1. [Qiskit 공식 교육 자료](http://qiskit.org/learn)
 2. [ 공식 샘플 테스트](https://www.ibm.com/training/certification/C0010300)
 3. [ James Weaver의 Qiskit 개발자 시험 준비 가이드](https://slides.com/javafxpert/prep-qiskit-dev-cert-exam)
@@ -21,6 +23,8 @@
 6.  [UIC Quantum Club의 Qiskit 개발자 시험 준비 강의 시리즈](https://www.youtube.com/playlist?list=PL3ZVRVvGqF1cH9SwNKBY-po3HXUPMlghg)
 7.  [Bartu Bisgin의 Qiskit 자격증 시험 워크북](https://github.com/bartubisgin/qiskit-certified-exam-workbook)
 8.  [Dimple12M의 가이드](https://github.com/dimple12M/Qiskit-Certification-Guide)
+
+## 강의 구성
 
 이 강의는 선형대수학과 양자역학이 낯선 분들을 위한 두개의 선행 노트와 함께 실질적인 개발자 시험을 준비하는데 도움이 될 다섯 개의 Jupyter notebook으로 구성되어 있습니다.  교재의 구성은 다음과 같습니다.
 
@@ -86,3 +90,7 @@
 >Use Qiskit Toolkit  
 >Display and use system information  
 >Sample test + lab materials  
+
+## 유의사항
+
+Qiskit 개발자 자격 시험은 `v0.2x.x`를 기준으로 합니다. 따라서 이 강의 노트들은 `v0.2x.x` 버전을 기준으로 작성되어 최신 Qiskit 버전에서는 작동하지 않을 수 있습니다. 따라서, [링크](https://github.com/QuantumComputingKorea/Qiskit-Dev-Cert-lectures/blob/main/HOWTO.md)를 참고하여 `v0.2x.x` 버전을 설치하거나, 바인더( [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Siheon-Park/Qiskit-Dev-Cert-lectures/main) )를 통해 강의 노트를 실행해주세요.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - [신소영](https://github.com/0sophy1)
 - [최인호](https://github.com/q-inho)
-- [박시헌](https://github.com/Siheon-Park)
+- [박시헌](https://github.com/Siheon-Park) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Siheon-Park/Qiskit-Dev-Cert-lectures/binder-trial)
 
 <b>많은 도움이 된 자료들</b>
 1. [Qiskit 공식 교육 자료](http://qiskit.org/learn)

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: qiskit-2x-test
+name: qiskit-2x
 dependencies:
   - python=3.8
   - pip=23.2.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: qiskit-2x-test
+dependencies:
+  - python=3.8
+  - pip=23.2.1
+  - pip:
+    - qiskit==0.29.1
+    - matplotlib==3.4.3
+    - ipykernel==6.25.2
+    - ipywidgets==8.1.1
+    - pylatexenc==2.10
+    - seaborn==0.13.0

--- a/postBuild
+++ b/postBuild
@@ -1,6 +1,6 @@
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -y
 source $HOME/.cargo/env
-conda create -n qiskit-2x python==3.8
+conda create -n qiskit-2x python==3.8 -y
 conda activate qiskit-2x
 pip install matplotlib==3.4.3 ipywidgets ipykernel pylatexenc seaborn
 python -m ipykernel install --user --name qiskit-2x --display-name "Python3.8 (qiskit-2x)"

--- a/postBuild
+++ b/postBuild
@@ -1,1 +1,0 @@
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,6 @@
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+conda create -n qiskit-2x python==3.8
+conda activate qiskit-2x
+pip install matplotlib==3.4.3 ipywidgets ipykernel pylatexenc seaborn
+python -m ipykernel install --user --name qiskit-2x --display-name "Python3.8 (qiskit-2x)"

--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -y
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source $HOME/.cargo/env
 conda create -n qiskit-2x python==3.8 -y
 conda activate qiskit-2x

--- a/postBuild
+++ b/postBuild
@@ -1,6 +1,1 @@
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source $HOME/.cargo/env
-conda create -n qiskit-2x python==3.8 -y
-conda activate qiskit-2x
-pip install matplotlib==3.4.3 ipywidgets ipykernel pylatexenc seaborn
-python -m ipykernel install --user --name qiskit-2x --display-name "Python3.8 (qiskit-2x)"


### PR DESCRIPTION
It turns out that rust compiler is not needed at all; python version should be 3.8, not 3.10. The binder link will not work until this commit is merged